### PR TITLE
Improve missing alias error

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ Add the plugin to your `.babelrc`.  Optionally, add a path to a webpack config f
 ```
 In this example, the plugin will only be run when `NODE_ENV` is set to `test`.
 
+## Notes
+
+- If using this plugin with [require-extension-hooks](https://github.com/jackmellis/require-extension-hooks) you'll need to add your webpack file to _hooks'_ [excludePattern](https://github.com/jackmellis/require-extension-hooks#excludepattern--fn) - otherwise the webpack config will always be required as empty. 
+
 ## Changes from the Babel 6 version
 
 - `config` option no longer uses lodash templates

--- a/src/index.js
+++ b/src/index.js
@@ -91,7 +91,7 @@ export default declare(api => {
 
             // Exit if there's no alias config
             if (isEmpty(aliasConfig)) {
-                throw new Error('The webpack config file does not contain an alias configuration');
+                throw new Error(`The webpack config file at — ${configPath} — does not contain an alias configuration`);
             }
 
             aliases = Object.keys(aliasConfig);


### PR DESCRIPTION
Specifying which file was read and found erroneous can help the user further diagnose problems.